### PR TITLE
fix: icon css crashes on webkit browsers

### DIFF
--- a/components/ProviderSelector/style.ts
+++ b/components/ProviderSelector/style.ts
@@ -31,7 +31,7 @@ export const FixedSizeItem = styled("div", {
     maxHeight: "8rem",
     width: "10rem",
     "&>svg": {
-        height: "fit-content",
+        height: "32px",
         width: "fit-content",
         maxHeight: "100%",
         maxWidth: "100%",


### PR DESCRIPTION
webkit 브라우저들에서 ProviderSelector 아이콘들이 깨지는 문제를 수정했습니다.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/48921632/150080851-2f367ff9-c648-4554-980b-5a720d379fb8.png">
